### PR TITLE
상점 아이템 구매 후 인벤토리 입장 시 버그 수정

### DIFF
--- a/Model/Character.cs
+++ b/Model/Character.cs
@@ -32,6 +32,7 @@ namespace TextRPGing.Model
         {
             Name = name;
             Job = job;
+            Level = 1;
 
             switch(Job) // 스탯 임의로 적어놨습니다. 랜덤으로 해도 재밌을거 같긴 하네요.
             {
@@ -45,7 +46,7 @@ namespace TextRPGing.Model
                     Skill = GameEnum.eSkillType.Warrior_skill.ToString();
                     break;
                 case Define.GameEnum.eCharacterClass.Thief:
-                    HP = 10;
+                    HP = 15;
                     MaxHP = 15;
                     ATK = 13;
                     DEF = 8;

--- a/Model/Potion.cs
+++ b/Model/Potion.cs
@@ -14,6 +14,7 @@ namespace TextRPGing.Model
 
         public Potion(int id, string name, GameEnum.eItemType type, string description, int price) : base(id, name, type, description, price)
         {
+            Heal = 30;
         }
     }
 }

--- a/Scene/SInventory.cs
+++ b/Scene/SInventory.cs
@@ -75,7 +75,7 @@ namespace TextRPGing.Scene
                 else
                 {
                     Console.WriteLine("세상에 포션을 싸울 때 쓰는 사람이 어디 있을까? 물건은 용도에 맞게 쓰자.");
-                    Thread.Sleep(1000);
+                    Thread.Sleep(2000);
                     return true;
                 }
             }
@@ -259,6 +259,7 @@ namespace TextRPGing.Scene
             byte[] data;
             int blank;
             string message = "";
+            if (item == null) return message; 
             switch (item.Type)
             {
                 case Define.GameEnum.eItemType.Weapon:

--- a/Scene/Store.cs
+++ b/Scene/Store.cs
@@ -44,7 +44,48 @@ namespace TextRPGing.Scene
                     if (mState == eState.Buy)
                     {
                         var item = Items[input - routes.Length - 1];
-                        Character.Player.Inven.AddItem(item);
+                        switch (item.Type)
+                        {
+                            case GameEnum.eItemType.Weapon:
+                                Weapon weaponToAdd = new Weapon(item.Name, item.Description, 0, 0, item.Price);
+                                if (weaponToAdd.Name == "숙련자의 검")
+                                {
+                                    weaponToAdd.ATK = 10;
+                                    weaponToAdd.CRT = 0.25f;
+                                }
+                                else if (weaponToAdd.Name == "불타는 검")
+                                {
+                                    weaponToAdd.ATK = 20;
+                                    weaponToAdd.CRT = 0.45f;
+                                }
+                                else
+                                {
+                                    weaponToAdd.ATK = 15;
+                                    weaponToAdd.CRT = 0.35f;
+                                }
+                                Character.Player.Inven.AddItem(weaponToAdd);
+                                break;
+                            case GameEnum.eItemType.Armor:
+                                Armor armorToAdd = new Armor(item.Name, item.Description, 0, 0, item.Price);
+                                if (armorToAdd.Name == "숙련자의 갑옷")
+                                {
+                                    armorToAdd.DEF = 10;
+                                    armorToAdd.AVD = 0.20f;
+                                }
+                                else if (armorToAdd.Name == "사슬갑옷")
+                                {
+                                    armorToAdd.DEF = 20;
+                                    armorToAdd.AVD = 0.45f;
+                                }
+                                else
+                                {
+                                    armorToAdd.DEF = 15;
+                                    armorToAdd.AVD = 0.30f;
+                                }
+                                Character.Player.Inven.AddItem(armorToAdd);
+                                break;
+                        }
+                        
                         Character.Player.Inven.Gold -= item.Price;
                     }
                     else


### PR DESCRIPTION
StoreItem.json에서 아이템 정보 불러와서 리스트 생성 시 각 아이템을 타입에 따라 Weapon, Armor 등 하위 클래스의 객체로 다시 
선언해야 다운캐스팅이 가능해서, 아이템을 구매하고 캐릭터 인벤토리에 넣을 때 해당 아이템의 정보를 토대로 각 아이템 타입에 맞는 새로운 하위 클래스의 객체를 다시 생성해서 인벤토리에 넣어주도록 했습니다.